### PR TITLE
feat: Add SHA256 checksum generation for release artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   test:
     name: Test on Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:
@@ -53,7 +53,7 @@ jobs:
           path: htmlcov/
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - test
     strategy:
@@ -90,7 +90,7 @@ jobs:
   release:
     name: GitHub Release
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: startsWith(github.ref, 'refs/tags/')
 
     steps:
@@ -102,6 +102,9 @@ jobs:
         with:
           name: build-dist
           path: dist/
+
+      - name: Generate packages sha256
+        run: for x in $(ls -1 dist/); do sha256sum --quiet dist/$x > dist/$x.sha256; done
 
       - name: Upload release artifacts
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,6 +103,10 @@ jobs:
           name: build-dist
           path: dist/
 
+      - name: Generate packages sha256
+        run: |
+          for x in $(ls -1 dist/); do sha256sum --quiet dist/$x > dist/$x.sha256; done
+
       - name: Upload release artifacts
         uses: softprops/action-gh-release@v2
         with:
@@ -110,3 +114,4 @@ jobs:
           files: |
             dist/*.whl
             dist/*.tar.gz
+            dist/*.sha256

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,9 +103,6 @@ jobs:
           name: build-dist
           path: dist/
 
-      - name: Generate packages sha256
-        run: for x in $(ls -1 dist/); do sha256sum --quiet dist/$x > dist/$x.sha256; done
-
       - name: Upload release artifacts
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@4
+        uses: actions/checkout@v4.2.2
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5.5.0
@@ -65,7 +65,7 @@ jobs:
           - "3.12"
     steps:
       - name: Checkout repo
-        uses: actions/checkout@4
+        uses: actions/checkout@v4.2.2
 
       - name: Set up Python
         uses: actions/setup-python@v5.5.0
@@ -95,7 +95,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,8 +104,7 @@ jobs:
           path: dist/
 
       - name: Generate packages sha256
-        run: |
-          for x in $(ls -1 dist/); do sha256sum --quiet dist/$x > dist/$x.sha256; done
+        run: for x in $(ls -1 dist/); do sha256sum --quiet dist/$x > dist/$x.sha256; done
 
       - name: Upload release artifacts
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@4.2.2
+        uses: actions/checkout@4
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5.5.0
@@ -65,7 +65,7 @@ jobs:
           - "3.12"
     steps:
       - name: Checkout repo
-        uses: actions/checkout@4.2.2
+        uses: actions/checkout@4
 
       - name: Set up Python
         uses: actions/setup-python@v5.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "certdiff"
-version = "0.2.4"
+version = "0.2.5"
 description = "Compare two X.509 certificates and detect critical differences."
 authors = [
     {name = "Fabio Felici", email = "fabio.felici@pagopa.it"},


### PR DESCRIPTION
### Summary

This pull request introduces SHA256 checksum generation for release artifacts. The CI workflow has been updated to compute checksums during the build process, and the artifact upload step now includes the checksum files. The project version has been incremented from 0.2.4 to 0.2.5. 

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate).